### PR TITLE
Added root ul node specific formatting

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,9 +10,19 @@ function formatContainer(container) {
     return container;
 }
 /**
+ * Formats Root UL element - can be overwritten in options
+ * @param: UL element
+ * @return: formatted UL element 
+ */
+function formatRootUl(ul) {
+    ul.className += ' ul-root-item';
+    return ul;
+}
+
+/**
  * Formats UL element - can be overwritten in options
  * @param: UL element
- * @return: formatted LI element 
+ * @return: formatted UL element 
  */
 function formatUl(ul) {
     ul.className = 'ul-item';
@@ -60,7 +70,8 @@ var _options = {
     formatUl: formatUl,
     formatLi: formatLi,
     formatProperty: formatProperty,
-    formatValue: formatValue
+    formatValue: formatValue,
+    formatRootUl:formatRootUl
 };
 
 function JSON2HTMLList(json, options) {
@@ -137,8 +148,13 @@ function JSON2HTMLList(json, options) {
         }
     }
 
-
+    
     walk(json, container);
+    
+    if(container.children.length > 0){
+        container.children[0] = _options.formatRootUl(container.children[0])
+    }
+
 
     return container;
 

--- a/sample.html
+++ b/sample.html
@@ -32,6 +32,17 @@ strong:after {
 
 (function() {
 
+    var options = {       
+        formatUl: function(ul) {
+            ul.className = 'my-ul-class';
+            return ul;
+        },
+        formatRootUl:function(ul){
+            ul.className = ul.className+" ul-root"
+            return ul;
+        }
+    }
+
 var myJSON = {
     "glossary": {
         "title": "example glossary",
@@ -57,7 +68,7 @@ var myJSON = {
 
 document.getElementById('input').appendChild(document.createTextNode(JSON.stringify(myJSON, null, 4)));
 
-document.getElementById('output').appendChild(JSON2HTMLList(myJSON));
+document.getElementById('output').appendChild(JSON2HTMLList(myJSON, options));
 
 })();
 


### PR DESCRIPTION
Existing Options were supporting only for container level and ul level which is applicable to all ul nodes. 

Root ul need to have some special properties, added a formatting function for that.